### PR TITLE
Add lesson plan drafts for SOP objectives and scope

### DIFF
--- a/lesson-plans/SOP-1000-01-AI_AI-Integrated-Program-and-Project-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1000-01-AI_AI-Integrated-Program-and-Project-Management-lesson-plan.md
@@ -1,0 +1,42 @@
+# Lesson Plan Draft: AI-Integrated Program and Project Management (AI-SDLC)
+
+**SOP Reference:** SOP-1000-01-AI_AI-Integrated-Program-and-Project-Management
+
+## Objective
+
+This SOP defines the *Program and Project Management* framework for AI-Integrated Systems Development Life Cycle (AI-SDLC) at Horizon. It includes processes for engaging the AI Institutional Review Board (AI-IRB) when a project involves regulated AI components or high-risk AI features. The objective is to ensure:
+
+1. Compliance with relevant AI governance, ethical guidelines, and regulatory standards (including AI-IRB).  
+2. Efficiency in delivering AI-enabled products or services, balancing scope, cost, and schedule constraints.  
+3. Quality in design, documentation, and rollout of new or enhanced functionalities that incorporate AI or ML (machine learning) modules.  
+4. Traceability from initial business need through final deployment and post-implementation review.
+
+## Audience & Applicability
+
+Covers all AI-related program and project management activities under the AI-SDLC umbrella. Includes focus areas such as Initiation, Planning, Execution & Monitoring, and Close-out. Applies to all Horizon teams: Product Development, AI-PMO, Engineering (Development, QA, Ops), Technical Support, and any external or contract resources.
+
+## Key Definitions
+
+- **AI-IRB**: *AI Institutional Review Board*, a governance body ensuring ethical and compliant oversight of AI modules, focusing on risk, bias, and regulatory compliance.
+- **AI-SDLC**: *AI-Integrated Systems Development Life Cycle*, a methodology that extends classical SDLC with specialized AI design, model governance, ethics, and monitoring controls.
+- **Program**: A collection of AI-related projects that share dependencies, resources, or strategic goals.
+- **Project**: A temporary endeavor to create or enhance AI-driven products/services with a defined scope, time, and cost constraints.
+- **Gate (Business Gate)**: A defined checkpoint in the AI-SDLC that requires specific deliverables to be approved before proceeding. Example: Gate 10 (Requirements Lock-Down), Gate 6 (Project Lock-Down), Gate 0 (General Availability).
+- **Deliverable**: Any project output requiring formal review/approval (e.g., AI risk assessment, system design, code modules, test results, AI model performance metrics).
+- **Performing Organization**: Typically the Engineering Department (Development, QA, Ops, AI specialists).
+- **Contracting Organization**: Typically the Product/Technical Support groups or external clients who define requirements and accept deliverables.
+
+## Key Roles
+
+- **Senior Management**: Establishes overall AI strategy and R&D budget; Commissions new AI projects; appoints AI Project Sponsors; Provides final decisions for resource trade-offs.
+- **AI-IRB**: Evaluates high-risk AI designs/changes for ethical, legal, and regulatory compliance; Issues formal approval or requests rework for AI modules prior to release.
+- **Project Sponsor**: Champions the AI-related project from concept to closure; Escalates issues to Senior Management; Final authority on scope changes, cost, schedule trade-offs for the project.
+- **AI-PMO**: Oversees the consolidated portfolio of AI-centric projects; Tracks cross-project dependencies, resource conflicts; Issues periodic status to Senior Management; ensures common standards, policies, and reporting.
+- **Product Manager**: Defines the business requirements for AI features; Aligns AI solutions to strategic goals; consults with AI-IRB if risk classification is uncertain; Coordinates user acceptance criteria with QA & end-users.
+- **Program Manager**: Manages day-to-day tasks across multiple AI projects under a single program; Ensures gating deliverables are completed; organizes reviews with AI-IRB, QA, and other stakeholders; Coordinates risk management activities.
+- **Project Manager**: Single project focus: planning, scheduling, budget management; Coordinates tasks among development, QA, AI-IRB, and operations; Maintains project documentation, issue logs, change requests.
+- **Development**: Implements AI system features and code changes; Provides estimates, tracks actuals vs. estimates; Submits technical design docs and code to QA & AI-IRB as necessary.
+- **Quality Assurance (QA)**: Defines test strategies for AI systems (functionality, data bias, model performance, ethics compliance); Approves system readiness at each gate; logs defects; Coordinates with AI-IRB on measuring AI compliance.
+- **Operations**: Provides infrastructure for AI model deployment, environment provisioning, version control, site monitoring; Executes deployment steps in production.
+- **Technical Support**: Acts as service organization and possibly training group; Provides first-level support for AI product usage after deployment.
+

--- a/lesson-plans/SOP-1001-01-AI_Document-Governance-and-AI-IRB-Compliance-lesson-plan.md
+++ b/lesson-plans/SOP-1001-01-AI_Document-Governance-and-AI-IRB-Compliance-lesson-plan.md
@@ -1,0 +1,41 @@
+# Lesson Plan Draft: Document Governance and AI-IRB Compliance
+
+**SOP Reference:** SOP-1001-01-AI_Document-Governance-and-AI-IRB-Compliance
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines and governs the creation, review, approval, control, storage, and archival of **all** documentation required in the **AI-SDLC** (Artificial Intelligence Systems Development Life Cycle). Given the heightened oversight for AI solutions, this SOP also incorporates **AI-IRB** (AI Institutional Review Board) compliance checks and approvals for any sensitive or high-risk AI systems.
+
+Key goals:
+
+* Ensure standardized document governance across all AI-related projects.  
+* Integrate **AI-IRB** regulatory requirements into the documentation lifecycle.  
+* Maintain clear traceability from concept through post-implementation.  
+* Protect confidentiality, integrity, and availability of project documents.
+
+## Audience & Applicability
+
+Applies to all individuals involved in producing, reviewing, or managing project-related documentation in the AI-SDLC. Includes focus areas such as Internal, External, and Lifecycle. All documents must adhere to the processes in this SOP to maintain compliance with regulatory, AI-IRB, and corporate governance standards.
+
+## Key Definitions
+
+- **Document**: Any written, graphic, or digital artifact capturing information relevant to AI-SDLC (e.g., requirements, designs).
+- **Document Owner**: The individual (or team) responsible for creating and maintaining a specific document.
+- **Document Control**: The process of systematic creation, review, approval, distribution, revision, and archival of documents.
+- **AI-IRB**: AI Institutional Review Board ensuring compliance with ethical, legal, and safety standards for AI projects.
+- **Revision**: Any version update to a document triggered by change requests, new data, or continuous improvements.
+- **Repository**: The official location (physical or digital) where documents are stored for version control and retrieval.
+
+## Key Roles
+
+- **AI Document Governance Team**: Oversees the entire document control process, ensures AI-IRB compliance, manages templates, and performs periodic audits.
+- **AI-IRB**: Reviews AI-related documentation for ethical, compliance, and safety concerns. Approves or mandates changes before release.
+- **Senior Management**: Provides strategic direction. Sponsors any large-scale changes to the document governance framework.
+- **Project Sponsor**: Champions the project and ensures document compliance at key milestones.
+- **AI-PMO**: Monitors overall project documentation progress, escalates issues, and ensures alignment with organizational standards and budgets.
+- **Program/Project Manager**: Ensures the creation, review, and final approval of project documents. Coordinates cross-functional sign-offs.
+- **Development**: Authors technical design docs, code architecture docs, integration detail docs, and responds to QA or IRB documentation feedback.
+- **Quality Assurance**: Reviews test strategies, test results, and ensures all necessary doc updates are made before gating to next phase.
+- **Operations**: Prepares environment configs and deployment records. Reviews final install documents.
+- **Technical Support**: Creates user guides, release notes, and training materials. Coordinates user documentation reviews with QA, Dev, and PM.
+

--- a/lesson-plans/SOP-1002-01-AI_Capacity-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1002-01-AI_Capacity-Management-lesson-plan.md
@@ -1,0 +1,30 @@
+# Lesson Plan Draft: Capacity Management (AI-Integrated)
+
+**SOP Reference:** SOP-1002-01-AI_Capacity-Management
+
+## Objective
+
+This **Standard Operating Procedure (SOP)** establishes the **Capacity Management** guidelines for AI-driven systems within the **AI-SDLC** (Systems Development Life Cycle) environment, ensuring **system resources** (compute, storage, memory, network) meet operational requirements for all **phases** (Development, Testing, Deployment, and Production). This SOP integrates specialized considerations for **AI-IRB** (AI Intelligences Review Board) oversight when capacity expansions or new AI components might impose ethical or compliance concerns.
+
+## Audience & Applicability
+
+Applies to All AI-SDLC projects that involve forecasting, planning, and managing capacity for AI solutions, from early requirements definition through post-deployment operational support. Includes focus areas such as Applies To, Out of Scope, and Exceptions.
+
+## Key Definitions
+
+- **AI-IRB**: AI Intelligences Review Board; ensures expansions or changes in AI capacity comply with ethical and safety reviews.
+- **Capacity Management**: The process of ensuring adequate system resources (compute, GPU, memory, storage, network) for AI solution demands.
+- **AI-SDLC**: Systems Development Life Cycle tailored for AI solutions, including AI-IRB gates and approvals.
+- **Trigger Event**: Any event requiring re-assessment of capacity (e.g., new dataset, user surge, new AI model version).
+- **Forecast**: The predicted usage, resource consumption, and performance requirements over time.
+
+## Key Roles
+
+- **Capacity Manager**: Oversees capacity planning, ensures resource availability, monitors performance trends, coordinates escalations.
+- **Project Manager**: Initiates capacity review in project planning, collects resource estimates from teams, and integrates them into overall project schedule/budget.
+- **AI Development Lead**: Provides AI workload details, usage patterns, new model release info. Collaborates with Capacity Manager on resource sizing.
+- **AI-IRB Liaison**: Determines if capacity changes for AI solutions might trigger an AI-IRB review for safety, ethics, or compliance concerns.
+- **Quality Assurance (QA)**: Verifies capacity readiness in testing phases, ensures performance metrics are met under load, logs capacity issues in defect tracking.
+- **Operations Team**: Implements capacity changes, monitors production usage, responds to threshold alerts, escalates to Capacity Manager.
+- **Product Owner / Sponsor**: Confirms business requirements, signs off on capacity expansions if cost/time exceed planned scope.
+

--- a/lesson-plans/SOP-1003-01-AI_Configuration-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1003-01-AI_Configuration-Management-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: Configuration Management
+
+**SOP Reference:** SOP-1003-01-AI_Configuration-Management
+
+## Objective
+
+This SOP establishes a consistent, controlled, and repeatable method for configuring, updating, and managing development, QA, staging, and production environments for AI-related systems. It clarifies responsibilities, processes, and quality checks to ensure changes are systematically planned, tested, documented, and reviewed, including where AI-IRB considerations apply.
+
+## Audience & Applicability
+
+Applies to all configuration changes (software, hardware, environment parameters, etc.) within the AI Systems Development Life Cycle (AI-SDLC). It includes management of AI model versions, data pipelines, HPC infrastructure, cloud or on-prem deployments, and any other environment or component whose change could affect system performance, functionality, or compliance. It also covers the integration of AI-IRB reviews where changes pose potential ethical/compliance impact or risk to end-users.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Configuration Manager**: Maintains the configuration management plan, tracks all changes, ensures CR documentation is complete, and updates the CI repository.
+- **AI Development Lead**: Proposes model/data changes, ensures changes follow coding standards, and coordinates with the AI-IRB Liaison for high-risk modifications.
+- **AI-IRB Liaison**: Determines if a proposed change triggers an AI-IRB review, coordinates the review process, communicates acceptance conditions.
+- **QA Representative**: Reviews, tests, and validates changes before they are moved beyond QA environment.
+- **Operations Team**: Implements changes in staging/production, maintains environment integrity, ensures correct rollback plan, and monitors post-deployment.
+- **Project Manager**: Oversees scheduling, resources, risk management, and ensures synergy with all project deliverables; escalates complex CRs if needed.
+- **Product Owner**: Approves significant changes, signs off on user impact statements, ensures alignment with business objectives.
+

--- a/lesson-plans/SOP-1004-01-AI_Procurement-and-Purchasing-for-AI-Enabled-Systems-lesson-plan.md
+++ b/lesson-plans/SOP-1004-01-AI_Procurement-and-Purchasing-for-AI-Enabled-Systems-lesson-plan.md
@@ -1,0 +1,28 @@
+# Lesson Plan Draft: Procurement and Purchasing for AI-Enabled Systems
+
+**SOP Reference:** SOP-1004-01-AI_Procurement-and-Purchasing-for-AI-Enabled-Systems
+
+## Objective
+
+The objective of this Standard Operating Procedure (SOP) is to document **an efficient and consistent** method for **procuring assets** needed to support AI-focused product development and/or business operations. This SOP places particular emphasis on **AI-related hardware, software licenses, data resources**, and **specialized tools** subject to AI-IRB or regulatory constraints.
+
+It ensures that **compliance, ethical considerations, risk management,** and **AI-IRB conditions** are integrated into the procurement lifecycle from request initiation to asset deployment.
+
+## Audience & Applicability
+
+Applies to all staff and departments within the AI-SDLC environment who are involved in purchasing or leasing assets (hardware, software, data sets, or third-party AI services) used in AI product development, QA, staging, or production. Includes focus areas such as Exclusions.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Requester**: 1. Identifies the need for an AI-related or standard asset. 2. Completes Procurement Request Form (including any relevant AI or data constraints).
+- **Requisitioner**: 1. Validates the request’s alignment with AI-IRB guidelines and technical requirements. 2. Prepares the Purchase Order (PO). 3. Tracks request lifecycle.
+- **AI-IRB Liaison**: 1. Ensures that assets subject to AI-IRB approval meet documented ethical and compliance conditions. 2. Advises Requisitioner on data usage or model licensing restrictions.
+- **Chief Financial Officer (CFO)**: 1. Reviews and signs off on PO if it exceeds the Approval Threshold. 2. Confirms budget availability and strategic alignment.
+- **CTO / Owner**: 1. Oversees overall procurement policy for AI systems. 2. Ensures synergy with broader AI-SDLC objectives.
+- **Office Manager (back-up)**: 1. May place the order if the requisitioner is not available. 2. Informs Requisitioner & Requester of delivery schedules.
+- **Asset Manager**: 1. Updates asset-tracking database upon receipt. 2. Manages warranties, licenses, compliance re-check for AI usage.
+

--- a/lesson-plans/SOP-1005-01-AI_AI-Integrated-Release-Planning-lesson-plan.md
+++ b/lesson-plans/SOP-1005-01-AI_AI-Integrated-Release-Planning-lesson-plan.md
@@ -1,0 +1,31 @@
+# Lesson Plan Draft: AI-Integrated Release Planning
+
+**SOP Reference:** SOP-1005-01-AI_AI-Integrated-Release-Planning
+
+## Objective
+
+The objective of this Standard Operating Procedure (SOP) is to define and document **AI-integrated release planning** activities in the **AI-SDLC** (Artificial Intelligence Systems Development Life Cycle). This procedure ensures that new or updated AI-based features or products are evaluated, prioritized, and scheduled in alignment with **business goals**, **AI-IRB** requirements, and **organizational** priorities.
+
+## Audience & Applicability
+
+Covers end-to-end release planning for AI-based software solutions, from preliminary concept or feature requests through the finalization of high-level commitments in Gate 10. It coordinates input from Product Development, AI-IRB Liaison, Technical Support, and Engineering, aiming to achieve a feasible and compliant release scope.
+
+## Key Definitions
+
+- **AI-IRB**: An internal (or external) AI Institutional Review Board responsible for ensuring that any AI features meet ethical and regulatory guidelines.
+- **SOW**: Scope of Work—document listing features, deliverables, costs, and resources for a given release or AI project.
+- **Release**: A set of AI-based features, enhancements, or bug fixes that are planned, developed, and deployed together as part of the AI-SDLC.
+- **Gates**: Predefined decision points in the AI-SDLC: from ideation (Gate 12) to general availability (Gate 0).
+- **Feasibility**: Assessment of resources (budget, staff), AI model readiness, ethical constraints, time, and complexity for each requested feature.
+
+## Key Roles
+
+- **AI-IRB Liaison**: Reviews planned AI features for ethical/regulatory compliance. Advises on acceptance or required modifications.
+- **Product Development**: Gathers feature requests (internal or external), defines priority and user-value alignment.
+- **Technical Support**: Inputs known production issues or user feedback for potential release.
+- **Engineering Department**: Provides feasibility (time, cost, AI model readiness) estimates, scope clarifications, technical guidance.
+- **PMO**: Consolidates release schedules, ensures cross-project alignment, and reports to senior management.
+- **Project Manager**: Facilitates release planning sessions, integrates inputs from all stakeholders, finalizes SOW documentation.
+- **Project Sponsor**: Arbitrates scope, cost, schedule conflicts. Endorses final release scope for Gate approval.
+- **Senior Management**: Sets overall business strategy, high-level R&D budgets, and final approval at key gates as needed.
+

--- a/lesson-plans/SOP-1006-01-AI_AI-IRB-Engagement-and-Ethical-Review-Procedure-lesson-plan.md
+++ b/lesson-plans/SOP-1006-01-AI_AI-IRB-Engagement-and-Ethical-Review-Procedure-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: AI-IRB Engagement and Ethical Review Procedure
+
+**SOP Reference:** SOP-1006-01-AI_AI-IRB-Engagement-and-Ethical-Review-Procedure
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the process for engaging with an AI Institutional Review Board (AI-IRB) or equivalent ethical/regulatory oversight body when developing, testing, and deploying AI-related features or products. The AI-IRB Engagement and Ethical Review Procedure ensures that all AI system components comply with regulatory, ethical, and data-handling requirements before proceeding through each phase of the AI Systems Development Life Cycle (AI-SDLC).
+
+## Audience & Applicability
+
+Applies to. Includes focus areas such as Applies To and Exclusions.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI-IRB Liaison**: Acts as the primary point of contact between project teams and the AI-IRB. Manages scheduling, submissions, and clarifications.
+- **Project Sponsor**: Ensures overall compliance with business objectives; has final sign-off on budgets and resources for AI-IRB compliance.
+- **Project Manager**: Coordinates project activities; ensures IRB tasks and requirements are integrated into the project plan and timeline.
+- **Development Team**: Provides technical details, risk assessments, and addresses IRB-related feedback on design, code, or data usage.
+- **Quality Assurance (QA)**: Ensures that all IRB-imposed constraints are tested and verified; reviews AI system logs or test results for compliance gaps.
+- **Operations**: Implements environment or infrastructure updates driven by IRB concerns; ensures safe data handling and disposal.
+- **Legal/Compliance**: Advises on regulatory implications; reviews any changes needed in data or usage agreements.
+

--- a/lesson-plans/SOP-1007-01-AI_AI-Asset-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1007-01-AI_AI-Asset-Management-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: AI Asset Management
+
+**SOP Reference:** SOP-1007-01-AI_AI-Asset-Management
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the responsibilities and methods used for the identification, tracking, monitoring, and management of **AI assets**, including both **hardware** (servers, storage devices, GPUs, specialized AI accelerators) and **software** (AI frameworks, models, datasets, and related tools). Additionally, it addresses the **AI-IRB (Intelligences Review Board)** compliance checkpoints necessary to ensure ethically and legally sound asset usage.
+
+## Audience & Applicability
+
+Applies to all AI-related technical acquisitions, usage, and lifecycle management across all SDLC phases, from initial deployment of AI hardware and software, through modifications or updates, and finally to the secure decommissioning/disposal of assets. This includes on-premise and cloud-based AI resources governed by the Performing Organization (Engineering Department) and relevant support from the AI-IRB.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Asset Owner**: • Coordinates daily usage of assigned AI asset • Reports any changes, reconfigurations, or problems to the Asset Manager • Ensures AI usage is within ethical and compliance guidelines set forth by the AI-IRB.
+- **Asset Manager**: • Maintains the AI Asset Tracking Database • Receives notifications about asset changes or new acquisitions • Updates asset records, including compliance tags if relevant • Checks with the AI-IRB Liaison if asset usage might pose compliance risks.
+- **AI-IRB Liaison**: • Reviews any new asset requests that might have ethical or compliance implications • Coordinates with external regulators or legal teams if needed • Approves or denies usage modifications based on ethical, privacy, or regulatory concerns.
+- **Operations**: • Provides final approval for deployment environment changes • Moves AI assets from staging to production or from on-premise to cloud environment • Implements security measures for AI asset storage or disposal.
+- **Engineering**: • Communicates new AI asset needs to the Asset Manager • Sets up environment for model training/inference • Performs and documents reconfiguration steps per the AI-IRB compliance guidelines.
+- **Technical Support**: • Addresses first-level issues with AI asset usage or environment • Routes advanced requests to Engineering or Asset Manager • Informs the AI-IRB Liaison if user queries hint at potential compliance or ethical concerns.
+- **Quality Assurance**: • Verifies correct usage of AI assets is documented and tested • Confirms that necessary steps for reconfiguration or disposal were followed • Issues corrective or preventive actions if asset usage fails any compliance or internal QA checks.
+

--- a/lesson-plans/SOP-1008-01-AI_AI-Incident-and-Escalation-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1008-01-AI_AI-Incident-and-Escalation-Management-lesson-plan.md
@@ -1,0 +1,33 @@
+# Lesson Plan Draft: AI Incident and Escalation Management
+
+**SOP Reference:** SOP-1008-01-AI_AI-Incident-and-Escalation-Management
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the steps and responsibilities for identifying, reporting, tracking, and escalating AI-related incidents in the **AI-SDLC** environment. An *AI-related incident* is any anomaly or unexpected event caused or impacted by an AI component that could result in system disruption, data compromise, adverse user impact, or risk to compliance/regulatory standards. The **AI-IRB** (Artificial Intelligence Institutional Review Board) is a key stakeholder in determining compliance or advanced risk escalations.
+
+## Audience & Applicability
+
+Covers the lifecycle of AI incident handling and escalation, including detection, triage, resolution, and the required follow-up in the AI-SDLC environment. It applies to all AI-related services, platforms, or processes within the organization. This includes.
+
+## Key Definitions
+
+- **AI-IRB**: Artificial Intelligence Institutional Review Board. Evaluates and approves AI usage from compliance and ethics standpoints.
+- **Incident**: Any unplanned or unexpected event that disrupts or has the potential to disrupt AI-based operations or that triggers ethical or compliance concerns.
+- **Escalation**: The formal process of raising an incident to a higher authority or specialized team (e.g. AI-IRB) for guidance, approval, or advanced troubleshooting.
+- **Triage**: Rapid initial assessment of an incident’s nature, severity, and impact to prioritize resources and next steps.
+- **SDLC**: System Development Life Cycle. In this context, it’s the specialized AI-SDLC framework.
+- **Ops**: Operations team. Responsible for system environment stability, including servers and deployments.
+- **TS**: Technical Support. The first line of contact for external or internal user queries or issues.
+
+## Key Roles
+
+- **Incident Reporter**: Submits the initial incident report upon noticing an AI anomaly or potential risk.
+- **Incident Manager**: Owns the incident from triage to closure, determines severity, and coordinates with other roles.
+- **Development**: Provides code/model fixes if required, including root-cause analysis for AI modules.
+- **AI-IRB Liaison**: Reviews incidents for compliance or ethical impact, escalates to AI-IRB if necessary.
+- **Operations**: Applies environment or configuration changes, monitors AI deployment health, and helps apply hotfixes.
+- **Quality Assurance**: Confirms the resolution effectiveness through testing, ensures no regression or additional side effects.
+- **Technical Support**: Receives external or user-reported incidents, logs them, and routes them to the Incident Manager.
+- **Security/Compliance**: Investigates incidents that indicate a data breach, regulatory violation, or major security flaw.
+

--- a/lesson-plans/SOP-1009-01-AI_AI-Model-Drift-and-Re-Validation-Procedure-lesson-plan.md
+++ b/lesson-plans/SOP-1009-01-AI_AI-Model-Drift-and-Re-Validation-Procedure-lesson-plan.md
@@ -1,0 +1,39 @@
+# Lesson Plan Draft: AI Model Drift and Re-Validation Procedure
+
+**SOP Reference:** SOP-1009-01-AI_AI-Model-Drift-and-Re-Validation-Procedure
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the *Model Drift and Re-Validation* activities required within the AI System Development Life Cycle (AI-SDLC). It ensures that AI solutions remain compliant, reliable, and high-performing over time. This SOP covers:
+
+* **Detection** of model/data drift triggers (technical, performance, data changes, domain shifts).  
+* **Impact analysis** on business logic, regulatory constraints, and user experience.  
+* **Periodic re-validation** to confirm the model’s ongoing suitability, fairness, and compliance.  
+* **Collaboration** with the AI-IRB (AI Institutional Review Board) for ethical, regulatory, and risk oversight.
+
+This SOP applies to all AI models (ML, NLP, neural networks, LLMs, etc.) used in production systems governed by \[Your Organization\]. All staff and vendors who implement or maintain these AI systems must comply with this procedure.
+
+## Audience & Applicability
+
+Covers This Standard Operating Procedure (SOP) defines the Model Drift and Re-Validation activities required within the AI System Development Life Cycle (AI-SDLC). It ensures that AI solutions remain compliant, reliable, and high-performing over time. This SOP covers. Applies to all AI models (ML, NLP, neural networks, LLMs, etc.) used in production systems governed by [Your Organization]. All staff and vendors who implement or maintain these AI systems must comply with this procedure.
+
+## Key Definitions
+
+- **Model Drift**: A change in model behavior or performance when the underlying data or environment differs significantly from training
+- **AI-IRB**: AI Institutional Review Board providing compliance, ethical, and regulatory oversight for AI projects
+- **Re-Validation**: Formal process of testing and re-assessing an AI model to ensure ongoing compliance, accuracy, reliability, etc.
+- **Trigger Event**: A measured threshold breach (performance drop) or business/regulatory change that initiates drift analysis
+- **Business Owner**: The stakeholder or sponsor who “owns” the AI solution’s business function
+- **Data Shift**: Statistical changes in input features, distribution, or user behaviors that cause mismatch from training data
+- **Bias Check**: Process for verifying that the model output or performance has not skewed in ways impacting protected groups
+
+## Key Roles
+
+- **AI-IRB Liaison**: Coordinates with the AI-IRB for oversight on model drift risk. Reviews ethical/regulatory concerns related to re-validation.
+- **Business Owner**: Owns the AI solution’s operational objectives. Approves re-validation budget and timelines.
+- **Data Scientist/Engineer**: Monitors model performance metrics, triggers drift analysis, performs re-validation tasks, and documents results.
+- **Quality Assurance (QA)**: Oversees the correctness and compliance of the re-validation steps, ensuring alignment with QA standards.
+- **Operations (Ops)**: Implements changes and updates in the production environment. Communicates production status and logs to the Data Scientist.
+- **Project Manager**: Manages scheduling, resource allocation, and communication between teams for re-validation tasks.
+- **Security/Compliance**: Assesses potential security, privacy, or other compliance implications during re-validation.
+

--- a/lesson-plans/SOP-1010-01-AI_AI-SDLC-Site-Monitoring-and-Incident-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1010-01-AI_AI-SDLC-Site-Monitoring-and-Incident-Management-lesson-plan.md
@@ -1,0 +1,25 @@
+# Lesson Plan Draft: AI-SDLC Site Monitoring and Incident Management
+
+**SOP Reference:** SOP-1010-01-AI_AI-SDLC-Site-Monitoring-and-Incident-Management
+
+## Objective
+
+This SOP defines the process for Site Monitoring and Incident Management in the AI-SDLC context, ensuring that AI-based systems in production are proactively monitored for stability, performance, and any unusual or critical incidents. It outlines the responsibilities, procedures, and escalation paths so that incidents are accurately identified, tracked, resolved, and documented.
+
+## Audience & Applicability
+
+Covers all AI-based applications and associated environments under the AI-SDLC Program.
+
+## Key Definitions
+
+- **AI-IRB**: The internal or external AI Institutional Review Board responsible for ethical compliance.
+- **Incident**: Any unplanned disruption, degradation, or security/privacy concern impacting production.
+- **Monitoring**: The proactive process of overseeing site performance and availability in real-time.
+- **Severity Levels**: Classification of incident criticality (e.g., P0, P1, P2).
+- **SLA**: Service Level Agreement defining performance and support obligations.
+- **MTR (Mean Time to Resolve)**: The average time required to resolve reported incidents.
+- **SaaS**: Software as a Service, indicating cloud/hosted solutions.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1011-01-AI_AI-Feature-Decommissioning-and-Model-Retirement-lesson-plan.md
+++ b/lesson-plans/SOP-1011-01-AI_AI-Feature-Decommissioning-and-Model-Retirement-lesson-plan.md
@@ -1,0 +1,23 @@
+# Lesson Plan Draft: AI Feature Decommissioning and Model Retirement
+
+**SOP Reference:** SOP-1011-01-AI_AI-Feature-Decommissioning-and-Model-Retirement
+
+## Objective
+
+The purpose of this Standard Operating Procedure (SOP) is to define and formalize the process for **decommissioning AI features** and **retiring AI models** used in the production environment, ensuring minimal disruption to users, compliance with ethical/AI-IRB guidelines, and proper knowledge transfer for potential future reference.
+
+## Audience & Applicability
+
+Applies to all SDLC AI-based features and machine learning models that are fully or partially deployed in production and must be disabled, removed, or deprecated from the live environment. It covers. This SOP does not cover the initial development or live operation of AI features; see the relevant SOPs (e.g., SOP-1003-01-AI, SOP-1010-01-AI) for those topics.
+
+## Key Definitions
+
+- **AI Feature**: Any user-facing or internal software functionality powered by machine learning or advanced AI models.
+- **AI Model**: A trained machine learning model or neural network used within a feature.
+- **Decommission/Retirement**: The formal process of removing an AI model or feature from the production environment and associated workflows.
+- **AI-IRB**: A special ethics and compliance review board for AI-based systems.
+- **Model Artifacts**: Files, logs, metadata, scripts, and any other items necessary to re-instantiate or audit the AI model.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1012-01-AI_AI-Model-Explainability-and-Interpretability-Procedure-lesson-plan.md
+++ b/lesson-plans/SOP-1012-01-AI_AI-Model-Explainability-and-Interpretability-Procedure-lesson-plan.md
@@ -1,0 +1,28 @@
+# Lesson Plan Draft: AI Model Explainability and Interpretability Procedure
+
+**SOP Reference:** SOP-1012-01-AI_AI-Model-Explainability-and-Interpretability-Procedure
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the methods and requirements by which the organization ensures **explainability and interpretability** of AI/ML models in production or under development. The procedure establishes guidelines to help internal stakeholders and external regulators understand and validate how AI models make decisions or predictions, while also ensuring compliance with ethical, legal, and AI-IRB (AI Institutional Review Board) requirements.
+
+## Audience & Applicability
+
+Applies to all AI/ML models developed, deployed, or maintained by the organization under the AI-SDLC process, whether they are for internal use or customer-facing. It includes.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI Dev Team**: Develops or integrates the AI model, including code for generating explainability and interpretability artifacts (e.g., feature importances, local explanations).
+- **AI-IRB Liaison**: Reviews the proposed explainability approaches, verifying compliance with ethical, legal, and regulatory guidelines.
+- **Product Management**: Ensures the product roadmap includes user-facing or client-facing explainability features when relevant.
+- **Data Science Lead**: Oversees the interpretability framework selection, ensuring the correct approach (global vs. local explanations, LIME, SHAP, etc.) is used.
+- **Quality Assurance (QA)**: Validates correctness of generated explanations, ensures no critical interpretability issues are found.
+- **Operations**: Implements and monitors any production-level model explanation pipelines or scheduled tasks to maintain up-to-date explanation reports.
+- **Legal/Compliance**: Verifies that the chosen explanation techniques meet regulatory requirements, particularly in sensitive or high-risk applications.
+- **Technical Support**: Provides user or client documentation to help interpret outputs; addresses end-user inquiries on how the model arrived at certain results.
+- **Senior Management**: Final decision authority and overall accountability for compliance; reviews escalations from AI-IRB or other stakeholders.
+

--- a/lesson-plans/SOP-1013-01-AI_AI-Model-Post-Production-Monitoring-and-Ongoing-Validation-lesson-plan.md
+++ b/lesson-plans/SOP-1013-01-AI_AI-Model-Post-Production-Monitoring-and-Ongoing-Validation-lesson-plan.md
@@ -1,0 +1,32 @@
+# Lesson Plan Draft: AI Model Post-Production Monitoring and Ongoing Validation
+
+**SOP Reference:** SOP-1013-01-AI_AI-Model-Post-Production-Monitoring-and-Ongoing-Validation
+
+## Objective
+
+The purpose of this Standard Operating Procedure (SOP) is to define a rigorous, consistent method for post-production monitoring and ongoing validation of AI/ML models within the organization’s environment. This procedure ensures that all deployed AI models continue to perform within acceptable parameters, remain compliant with relevant regulations, and address any potential performance or ethical concerns over time.
+
+## Audience & Applicability
+
+Applies to all AI/ML models deployed in production by the organization, including (but not limited to) supervised, unsupervised, and reinforcement learning models. It covers every phase post-deployment, including performance monitoring, drift detection, revalidation, stakeholder notification, and documentation of all updates or model changes. This SOP references and extends any requirements set by the AI-IRB, relevant regulatory guidelines, and corporate best practices.
+
+## Key Definitions
+
+- **AI-IRB**: The AI Institutional Review Board responsible for ethical, regulatory, and compliance oversight.
+- **Model Drift**: A significant change in data patterns (feature distribution) or changes in model performance over time.
+- **Performance Threshold**: Predefined standard(s) for acceptable model outputs (accuracy, recall, etc.) outlined in project scope.
+- **Retraining**: The process of updating or re-fitting an AI model using new data or refined parameters.
+- **Monitoring Horizon**: The interval or schedule at which the model’s performance is systematically evaluated.
+- **Alert Trigger**: An automated mechanism that flags unusual or substandard performance requiring further investigation.
+
+## Key Roles
+
+- **AI Dev Team**: Implements monitoring hooks, addresses performance/drift issues, coordinates with Data Science Lead for model retraining, and updates code repositories.
+- **Data Science Lead**: Oversees performance metrics, designs drift detection protocols, ensures revalidation is consistent with the originally stated business and regulatory objectives.
+- **AI-IRB Liaison**: Confirms that any modifications to the model remain compliant with ethical and regulatory guidelines. Reviews any new data usage or expanded scope for compliance.
+- **MLOps Engineer**: Creates, configures, and maintains production monitoring pipelines; ensures version control for all changes and synchronization across environments.
+- **Quality Assurance**: Audits performance logs, ensures compliance with acceptance criteria, and organizes periodic reviews in coordination with AI-IRB Liaison.
+- **Technical Support**: Acts as frontline contact for user issues or feedback about model outputs. Notifies AI Dev Team of any anomalies or user-facing performance concerns.
+- **Operations Manager**: Manages system-level performance and availability, ensures that infrastructure scaling or changes do not compromise model monitoring or logging systems.
+- **Legal/Compliance**: Advises on any new constraints arising from data privacy laws, intellectual property rights, or other regulatory frameworks if additional data or new model usage is introduced.
+

--- a/lesson-plans/SOP-1014-01-AI_Regulatory-and-Ethical-AI-Compliance-Verification-lesson-plan.md
+++ b/lesson-plans/SOP-1014-01-AI_Regulatory-and-Ethical-AI-Compliance-Verification-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: Regulatory & Ethical AI Compliance Verification
+
+**SOP Reference:** SOP-1014-01-AI_Regulatory-and-Ethical-AI-Compliance-Verification
+
+## Objective
+
+This Standard Operating Procedure (SOP) outlines the **Regulatory & Ethical AI Compliance Verification** process to ensure that all AI systems, models, and related components adhere to relevant regulations, ethical guidelines, and AI-IRB requirements. It defines the steps to verify compliance before any system is deployed or updated in a production environment.
+
+## Audience & Applicability
+
+Applies to all AI/ML projects within the organization, from initial concept through post-deployment monitoring.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI Dev Team**: Implement compliance checks in code, follow ethical data usage guidelines, fix any flagged compliance issues.
+- **Data Scientist**: Evaluate data sets, model outputs for potential biases; collaborate with compliance team for risk analysis.
+- **AI-IRB Liaison**: Facilitate IRB review process, track required ethical approvals, ensure all mandatory forms are submitted.
+- **Project Manager**: Maintain project schedules, incorporate compliance tasks and milestones, escalate risks or delays.
+- **Quality Assurance**: Conduct compliance verification audits, track compliance issues, verify no open compliance blockers.
+- **Legal/Compliance**: Confirm alignment with relevant regulations (GDPR, HIPAA, etc.), sign off before production deployment.
+- **MLOps/Operations**: Enforce compliance gates in release pipeline, ensure final system meets IRB approvals and legal/regulatory sign-offs.
+

--- a/lesson-plans/SOP-1015-01-AI_AI-Knowledge-Transfer-and-Handover-Procedure-lesson-plan.md
+++ b/lesson-plans/SOP-1015-01-AI_AI-Knowledge-Transfer-and-Handover-Procedure-lesson-plan.md
@@ -1,0 +1,30 @@
+# Lesson Plan Draft: AI Knowledge Transfer and Handover Procedure
+
+**SOP Reference:** SOP-1015-01-AI_AI-Knowledge-Transfer-and-Handover-Procedure
+
+## Objective
+
+This Standard Operating Procedure (SOP) provides a detailed method for **knowledge transfer** (KT) and **handover** activities within an **AI project lifecycle**. It ensures continuity, comprehension, and responsible stewardship when AI systems transition between teams (e.g., from Development to Operations, or from an external vendor to an internal group). This SOP addresses roles, steps, required documentation, and best practices for knowledge dissemination, specifically tailored to the complexities of AI models, data, and ongoing compliance with AI-IRB guidelines.
+
+## Audience & Applicability
+
+Covers 1. Applicability. 2. Exclusions.
+
+## Key Definitions
+
+- **AI-IRB**: Internal Review Board for AI, ensuring responsible AI governance, compliance, and ethics.
+- **Handover**: The process of transferring ownership of AI code, data, and knowledge from one entity to another.
+- **KT (Knowledge Transfer)**: Structured approach to share domain, technical, and operational knowledge about an AI solution.
+- **Receiving Org**: The group taking responsibility for the AI solution post-handover.
+- **Handover Package**: Collection of documents, model artifacts, code, test logs, compliance checklists, etc. used for knowledge transfer.
+
+## Key Roles
+
+- **Project Manager (PM)**: Oversees the knowledge transfer timeline, ensures tasks are planned and completed, coordinates cross-functional sign-offs.
+- **AI-IRB Liaison**: Verifies continuing compliance with AI-IRB stipulations, ensures all relevant guidelines are included in the handover.
+- **AI Development Team**: Prepares code repositories, model documentation, addresses open technical questions.
+- **Data Scientist**: Provides dataset specifics, feature engineering details, data documentation, and provenance.
+- **MLOps/Operations**: Understands production environment, operational metrics, pipeline orchestrations; ensures environment readiness.
+- **Quality Assurance (QA)**: Checks completeness and correctness of handover package, validates final compliance logs, organizes final sign-offs.
+- **Receiving Organization**: Participates in knowledge transfer sessions, reviews documentation, provides acceptance sign-off.
+

--- a/lesson-plans/SOP-1020-01-AI_AI-Model-Lifecycle-Management-lesson-plan.md
+++ b/lesson-plans/SOP-1020-01-AI_AI-Model-Lifecycle-Management-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: AI Model Lifecycle Management
+
+**SOP Reference:** SOP-1020-01-AI_AI-Model-Lifecycle-Management
+
+## Objective
+
+The objective of this Standard Operating Procedure (SOP) is to define a structured approach for the entire lifecycle of AI models, from initial concept and data sourcing through development, validation, deployment, monitoring, retraining, and eventual decommissioning or retirement. This ensures consistent, high-quality processes, while adhering to ethical, regulatory, and operational standards (including AI-IRB oversight).
+
+## Audience & Applicability
+
+Applies to all AI models developed, maintained, or deployed under the organization’s purview. All teams and roles involved in the creation, oversight, or usage of AI-based technologies must comply with this SOP.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Project Sponsor**: Allocates budget, approves major AI-IRB initiatives, resolves high-level scope changes.
+- **AI-IRB Liaison**: Coordinates AI-IRB reviews and approvals, ensures compliance with ethical/regulatory guidelines.
+- **Data Scientist**: Designs models, orchestrates dataset collection, runs experiments. Documents approach for AI-IRB compliance.
+- **MLOps/Operations**: Manages environment setups for training, staging, and production. Oversees CI/CD pipelines, monitors model behavior.
+- **Quality Assurance**: Reviews model output quality, ensures SOP adherence, verifies compliance with AI-IRB conditions.
+- **Development Team**: Implements application logic, integrates the model into the software solution, handles version control.
+- **Business Stakeholder**: Outlines functional requirements and success criteria, provides domain knowledge, and ensures business alignment.
+- **Model Owner**: Accountable for the model’s business performance, organizes periodic reviews with QA and AI-IRB Liaison, can request retraining or retirement.
+

--- a/lesson-plans/SOP-1030-01-AI_AI-Ad-Hoc-Reporting-Procedure-lesson-plan.md
+++ b/lesson-plans/SOP-1030-01-AI_AI-Ad-Hoc-Reporting-Procedure-lesson-plan.md
@@ -1,0 +1,28 @@
+# Lesson Plan Draft: AI-Ad Hoc Reporting Procedure
+
+**SOP Reference:** SOP-1030-01-AI_AI-Ad-Hoc-Reporting-Procedure
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the process for requesting, generating, and delivering **ad hoc AI-based reporting** in alignment with the AI-SDLC. It provides guidelines to ensure compliance with the AI-IRB (Artificial Intelligence Institutional Review Board) and fosters consistent, timely, and accurate reporting of analytics, insights, and metrics beyond scheduled or routine outputs.
+
+## Audience & Applicability
+
+Applies to all requests for one-time or urgent AI-driven data insights, as well as non-routine analytics that leverage the organization’s data platforms, ML/AI models, or big data infrastructure. It covers. Excluded from scope.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Requestor**: Submits ad hoc AI-reporting request, providing clear objectives, scope, timeline, and compliance considerations.
+- **AI IRB Liaison**: Verifies that any ethical, regulatory, or privacy implications are vetted before an ad hoc request is processed.
+- **AI Data Analyst**: Receives request from Requestor, refines requirements, and ensures alignment with AI governance frameworks.
+- **Data Scientist**: Reviews AI or ML model usage needed for the ad hoc request, ensures model interpretability, compliance, and validity.
+- **MLOps Engineer**: Sets up or updates necessary computing environments, manages version control of data scripts and integrated ML code.
+- **Quality Assurance**: Ensures the ad hoc report meets acceptance criteria, verifies data correctness, and logs any defects for resolution.
+- **Operations**: Manages final distribution or automation of the ad hoc request outputs if needed.
+- **Technical Support**: Provides Tier 1 user training and help desk function for questions about the final ad hoc report or results.
+- **AI Ethics/Compliance**: Monitors any compliance or privacy constraints associated with data or model usage in the request.
+

--- a/lesson-plans/SOP-1040-01-AI_Requirements-Definition-lesson-plan.md
+++ b/lesson-plans/SOP-1040-01-AI_Requirements-Definition-lesson-plan.md
@@ -1,0 +1,30 @@
+# Lesson Plan Draft: Requirements Definition
+
+**SOP Reference:** SOP-1040-01-AI_Requirements-Definition
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the process for **Requirements Definition** within the AI Systems Development Life Cycle (AI-SDLC). It ensures that all business, regulatory, ethical, and technical requirements for AI-related projects are systematically identified, analyzed, documented, and approved, including integration with the **AI Institutional Review Board (AI-IRB)** as needed.
+
+## Audience & Applicability
+
+Applies to all AI-focused software and system development projects at the organization that require formal requirements capture. It addresses. All departments—Product Development, Engineering, Quality Assurance, Operations, Technical Support, and the AI IRB—must follow this SOP for any AI-related project or feature release that goes through the AI-SDLC.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI Project Sponsor**: Champions the project, obtains funding, and ensures high-level alignment with AI/ethical guidelines.
+- **AI IRB Liaison**: Reviews potential AI ethics impacts, organizes IRB reviews, ensures compliance with AI IRB directives.
+- **Product Manager**: Leads the business vision, compiles user/business requirements, and coordinates with AI IRB Liaison.
+- **AI Business Analyst**: Elicits, documents, and validates all business and user requirements with an AI lens.
+- **AI Data Scientist**: Advises on feasibility and data-related requirements, ensuring correctness for AI/ML solutions.
+- **Quality Assurance (QA)**: Reviews requirements for testability, ensures acceptance criteria are well-defined and trackable.
+- **AI Ethics/Compliance**: Monitors regulatory, ethical, privacy, and fairness aspects in the requirement definitions.
+- **Operations**: Contributes operational, infrastructure, and deployment constraints or requirements.
+- **Technical Support**: Communicates user needs, logs known constraints, and receives training for future user support.
+- **Program Manager**: Oversees schedule, budget, resources, ensures synergy among cross-functional teams.
+- **Development**: Provides input on technical constraints and ensures feasibility for system or platform requirements.
+

--- a/lesson-plans/SOP-1050-01-AI_AI-Security-Administration-and-Governance-lesson-plan.md
+++ b/lesson-plans/SOP-1050-01-AI_AI-Security-Administration-and-Governance-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: AI Security Administration and Governance
+
+**SOP Reference:** SOP-1050-01-AI_AI-Security-Administration-and-Governance
+
+## Objective
+
+This SOP defines the policies and procedures for managing and administering security for AI-based systems and resources within the organization. It ensures that AI-related data, models, and infrastructure are protected against unauthorized access, misuse, or compromise, and that all security practices comply with relevant legal, regulatory, and ethical standards, including AI IRB review.
+
+## Audience & Applicability
+
+Applies to all AI projects, systems, and personnel within the organization, as well as any third-party vendors or collaborators who interact with or manage our AI environments.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI Project Sponsor**: Provides overall direction and ensures sufficient resources for security measures.
+- **AI IRB Liaison**: Coordinates with AI IRB for any new AI security approvals or changes that might have ethical/regulatory impact.
+- **Security Administrator**: Implements and maintains security controls for all AI environments, manages user accounts, reviews logs, oversees password policies.
+- **AI Development Team**: Adheres to secure coding standards, escalates vulnerabilities to Security Administrator.
+- **Data Science / AI Engineering Team**: Ensures data usage, model training, and deployment align with security best practices, engages Security Administrator for critical changes.
+- **Operations**: Provides infrastructure security, manages environments (dev, QA, production), implements patching and monitoring.
+- **Quality Assurance**: Verifies security compliance in test phases, coordinates vulnerability scans.
+- **Technical Support**: First-level triage for security-related AI support requests, escalates issues to the Security Administrator.
+

--- a/lesson-plans/SOP-1051-01-AI_AI-Security-Administration-and-Oversight-lesson-plan.md
+++ b/lesson-plans/SOP-1051-01-AI_AI-Security-Administration-and-Oversight-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: AI Security Administration and Oversight
+
+**SOP Reference:** SOP-1051-01-AI_AI-Security-Administration-and-Oversight
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines and governs the security administration and oversight processes for AI-based systems in the organization. It ensures that AI solutions meet regulatory requirements, including the AI Institutional Review Board (AI-IRB) guidelines, protecting both intellectual assets and sensitive data throughout the System Development Life Cycle (SDLC).
+
+## Audience & Applicability
+
+Applies to all AI or machine learning (ML) systems managed or developed by the organization, including pilot projects, prototypes, and production AI deployments. It encompasses user access control, regulatory compliance checks via the AI-IRB, security logs monitoring, and incident handling for any AI-related security events.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI Project Sponsor**: Provides strategic direction and ensures funding for security measures.
+- **AI-IRB Liaison**: Acts as the primary contact between the project team and the AI-IRB, ensuring ethical and regulatory checks.
+- **Security Administrator**: Implements, monitors, and audits security controls, manages user requests, and escalates compliance issues.
+- **Development Team**: Submits access requests, adheres to coding security best practices, cooperates with audits or investigations.
+- **Data Science Team**: Ensures data usage within AI models complies with security policies; works with Security Admin on logs.
+- **Operations**: Maintains infrastructure security, applies patches, and implements recommended changes or fixes.
+- **Quality Assurance**: Performs security validation tests, assists in incident investigations, and ensures adherence to standards.
+- **Technical Support**: Receives escalations for security incidents from users, logs them, and coordinates with SecAdmin.
+

--- a/lesson-plans/SOP-1052-01-AI_AI-Model-Lifecycle-Oversight-and-Governance-lesson-plan.md
+++ b/lesson-plans/SOP-1052-01-AI_AI-Model-Lifecycle-Oversight-and-Governance-lesson-plan.md
@@ -1,0 +1,23 @@
+# Lesson Plan Draft: AI Model Lifecycle Oversight and Governance
+
+**SOP Reference:** SOP-1052-01-AI_AI-Model-Lifecycle-Oversight-and-Governance
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the processes for overseeing AI model lifecycle events under the AI-SDLC. It establishes methods for ensuring compliance with AI regulatory board requirements, continuous performance monitoring, data governance, and structured communication among key stakeholders.
+
+## Audience & Applicability
+
+Applies to all AI models developed, tested, and deployed under the AI-SDLC within the organization. It specifically addresses procedures from model inception to decommissioning, ensuring ethical and regulatory compliance throughout the model’s life.
+
+## Key Definitions
+
+- **AI-IRB**: The internal or external board providing ethical oversight and compliance review for AI projects.
+- **Model Lifecycle**: The set of phases from model design, data acquisition, build, test, deployment, to retirement.
+- **Performance Metrics**: Quantitative or qualitative measures for model accuracy, fairness, security, and reliability.
+- **Gate Reviews**: Formal checkpoints within the AI-SDLC for verifying readiness before proceeding to the next phase.
+- **Champion/Challenger**: An approach where two or more AI models compete in parallel; the best performer is selected for production.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1053-01-AI_Ethical-Risk-Assessment-and-Mitigation-lesson-plan.md
+++ b/lesson-plans/SOP-1053-01-AI_Ethical-Risk-Assessment-and-Mitigation-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: Ethical Risk Assessment & Mitigation
+
+**SOP Reference:** SOP-1053-01-AI_Ethical-Risk-Assessment-and-Mitigation
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the methodology and responsibilities for conducting Ethical Risk Assessments and formulating Mitigation Plans for AI-related projects throughout the AI-SDLC lifecycle. It establishes guidelines to ensure that potential ethical, privacy, and safety concerns are identified, assessed, and appropriately mitigated before and after model deployment.
+
+## Audience & Applicability
+
+Applies to all AI system or feature releases managed under the AI-SDLC, especially those requiring compliance with internal corporate policies, external regulatory constraints, or that directly involve personal data processing and autonomy. It is mandatory for all functional teams—including Development, Quality Assurance, Operations, and Product/Project Management—whenever an AI model or AI-driven solution is planned, developed, tested, and deployed.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Product Management**: Initiates ethical risk evaluation during product ideation; ensures sufficient resources for risk analysis.
+- **Development Team**: Documents technical aspects, user stories, and any potential ethical impact or risk triggers from the solution.
+- **AI Ethics Committee**: Performs thorough review of ethical risk; sets risk thresholds and approves or escalates mitigation strategies.
+- **AI-IRB Liaison**: Coordinates with AI-IRB to ensure compliance with applicable ethical guidelines.
+- **Quality Assurance**: Verifies the ethical risk assessment steps are completed as part of the AI-SDLC gating processes.
+- **Operations Team**: Implements environment controls and ensures mitigation tactics are enforced in production.
+- **Legal & Compliance**: Reviews regulatory and legal obligations. Advises on data protection, liability, and other compliance concerns.
+- **Data Protection Officer (DPO)**: Conducts privacy impact assessments; ensures alignment with data-protection laws (GDPR, etc.).
+

--- a/lesson-plans/SOP-1054-01-AI_AI-Regulated-Project-Approvals-and-Sponsorship-lesson-plan.md
+++ b/lesson-plans/SOP-1054-01-AI_AI-Regulated-Project-Approvals-and-Sponsorship-lesson-plan.md
@@ -1,0 +1,23 @@
+# Lesson Plan Draft: AI-Regulated Project Approvals and Sponsorship
+
+**SOP Reference:** SOP-1054-01-AI_AI-Regulated-Project-Approvals-and-Sponsorship
+
+## Objective
+
+This Standard Operating Procedure (SOP) provides a structured methodology for obtaining approvals, sponsorship, and oversight of AI-related projects within the organization. It defines the steps, responsibilities, and deliverables required to ensure thorough evaluation by relevant stakeholders—most notably the AI-IRB (AI Institutional Review Board)—and alignment with strategic, legal, and ethical standards.
+
+## Audience & Applicability
+
+Applies to all AI-related projects requiring corporate approval, budget allocation, or strategic sponsorship. It encompasses new projects, major enhancements, incremental updates, and pilot programs where AI-based solutions are developed or deployed. All employees, contractors, or partners engaged in these AI projects must adhere to this SOP before requesting official project approval or sponsorship.
+
+## Key Definitions
+
+- **AI-IRB**: The AI Institutional Review Board or advisory committee
+- **PM**: Project Manager
+- **Sponsor**: The senior manager or executive endorsing the AI project
+- **ROI**: Return on Investment
+- **Feasibility**: Preliminary study analyzing viability of the AI project
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1055-01-AI_Computer-System-Controls-lesson-plan.md
+++ b/lesson-plans/SOP-1055-01-AI_Computer-System-Controls-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: Computer System Controls
+
+**SOP Reference:** SOP-1055-01-AI_Computer-System-Controls
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the policies and responsibilities for implementing, maintaining, and monitoring **computer system controls** within the AI-SDLC environment. By following this procedure, SDLC teams and relevant stakeholders ensure that all systems and associated data remain secure, reliable, and compliant with organizational, AI-IRB, and regulatory requirements.
+
+## Audience & Applicability
+
+Applies to all AI-driven software development projects, including computer systems used for development, testing, production, and maintenance in the SDLC. It covers.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **System Owner**: Ensures the system meets operational, compliance, and security requirements.
+- **AI-IRB Liaison**: Coordinates with AI-IRB Board to ensure ethical and regulatory compliance of computer system controls.
+- **Security Compliance Manager**: Oversees risk assessments, approves security settings, and monitors compliance with security policies.
+- **Development Team**: Implements code changes, follows version control procedures, ensures system documentation is up to date.
+- **Operations Manager**: Maintains operational integrity of systems, coordinates changes to hardware/software, enforces standardized SOPs.
+- **Quality Assurance**: Verifies system control documentation, ensures testing addresses relevant system controls, logs findings.
+- **Project Manager**: Oversees planning, ensures tasks are assigned, logs issues, drives changes through Change Control procedure.
+- **Technical Support**: Assists with troubleshooting, user training on system usage, reports issues to the relevant teams.
+

--- a/lesson-plans/SOP-1060-01-AI_Service-Level-Agreement-lesson-plan.md
+++ b/lesson-plans/SOP-1060-01-AI_Service-Level-Agreement-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: . Objective
+
+**SOP Reference:** SOP-1060-01-AI_Service-Level-Agreement
+
+## Objective
+
+This Standard Operating Procedure (SOP) provides a structured method for defining, designing, and implementing a **Service Level Agreement (SLA)** in the context of the **AI-SDLC** (AI Systems Development Life Cycle). The SLA ensures that service expectations—such as performance, availability, ethics compliance, and support—are explicitly defined and managed for AI-related projects/systems.
+
+## Audience & Applicability
+
+Applies to all AI-driven solutions managed under the AI-SDLC process.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI Service Delivery Manager**: Oversees SLA creation, bridging user (customer) needs with AI-specific compliance.
+- **Product Manager**: Identifies business requirements for the SLA and reviews alignment with product objectives.
+- **Operations Manager**: Defines and implements capacity, availability, and continuity strategies to meet SLA commitments (including relevant security and performance obligations).
+- **AI-IRB Liaison**: Validates that the SLA includes ethical usage constraints and relevant monitoring to ensure AI compliance.
+- **Quality Assurance (QA)**: Reviews SLA acceptance criteria, verifies metrics, and ensures compliance with performance or reliability goals.
+- **Legal/Contracts Team**: Assists in formalizing the SLA contractual language, particularly around AI data usage, privacy, and compliance.
+- **Project Manager**: Incorporates the SLA into the overall project plan, ensures the tasks and timelines for SLA are clearly documented and managed, and communicates changes to stakeholders.
+- **Client/Customer**: Provides service expectations, signs off on SLA scope, and collaborates on measuring ongoing compliance.
+

--- a/lesson-plans/SOP-1061-01-AI_Incident-Tracking-lesson-plan.md
+++ b/lesson-plans/SOP-1061-01-AI_Incident-Tracking-lesson-plan.md
@@ -1,0 +1,32 @@
+# Lesson Plan Draft: Incident Tracking
+
+**SOP Reference:** SOP-1061-01-AI_Incident-Tracking
+
+## Objective
+
+This SOP describes the standardized method for **incident tracking** within the AI-SDLC environment to ensure all production incidents (defects) are reported, triaged, documented, and resolved efficiently.
+
+## Audience & Applicability
+
+Applies to all AI-related production incidents that occur post-deployment, including software malfunctions, data quality anomalies, or user-facing disruptions.
+
+## Key Definitions
+
+- **Incident**: Any unexpected behavior, defect, or anomaly in production systems requiring immediate action.
+- **Incident Logging**: The process of recording details about the incident, such as date/time, severity, steps.
+- **AI-IRB**: The internal/external AI Institutional Review Board ensuring compliance with ethical AI use.
+- **Severity Level**: Classification of incident urgency (e.g. Emergency, High, Medium, Low) to set resolution priority.
+- **Root-Cause**: The fundamental technical or procedural reason behind the incident.
+- **SLA**: Service Level Agreement specifying commitments on incident response & resolution.
+- **Production**: The environment or set of systems actively serving end-users or clients.
+
+## Key Roles
+
+- **Defect Reporter**: Identifies and reports an incident, providing essential info (symptoms, environment, steps to reproduce).
+- **Technical Support**: Acts as the funnel for external client incidents; logs or rejects with explanation if incomplete; escalates for triage.
+- **Quality Assurance**: Oversees the centralized tracking system (e.g., SQA Manager); validates severity, ensures thorough documentation.
+- **AI-IRB Liaison**: Reviews incidents with ethical implications; ensures compliance with AI responsibility guidelines.
+- **Development**: Investigates, fixes code or data issues, re-tests, and coordinates release of patches or emergency pushes.
+- **Operations**: Confirms production environment readiness for patches; coordinates with QA to deploy fixes safely.
+- **Project Manager**: Monitors incident resolution progress; communicates updates to stakeholders, ensures SLA adherence.
+

--- a/lesson-plans/SOP-1100-01-AI_Documentation-of-Training-lesson-plan.md
+++ b/lesson-plans/SOP-1100-01-AI_Documentation-of-Training-lesson-plan.md
@@ -1,0 +1,31 @@
+# Lesson Plan Draft: Documentation of Training
+
+**SOP Reference:** SOP-1100-01-AI_Documentation-of-Training
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the process for creating and maintaining documentation of job-related training for personnel participating in the AI-SDLC (Artificial Intelligence Systems Development Life Cycle), including mandatory AI-IRB compliance requirements as applicable. This procedure ensures that all training records are properly maintained and accessible for audit, regulatory, or operational needs.
+
+## Audience & Applicability
+
+Applies to all internal and external training programs that pertain to AI-SDLC activities, especially those subject to AI-IRB regulations. It also includes project-specific training, both client-facing and internally required, that is relevant to the design, development, testing, deployment, or maintenance of AI-driven or AI-related systems at the organization.
+
+## Key Definitions
+
+- **AI-SDLC**: The Systems Development Life Cycle adapted for AI-driven solutions, with AI-IRB oversight where required.
+- **AI-IRB**: The AI Institutional Review Board ensuring ethical and regulatory compliance for AI projects.
+- **Trainer**: The individual(s) delivering training (internal or external).
+- **Training Coordinator**: The person (often in HR or departmental lead) who organizes and tracks training events and records.
+- **Project-Specific Training**: Training tied to a defined feature, project, or protocol within the AI-SDLC.
+- **External Training**: Training provided by outside entities (seminars, conferences, vendor training, etc.).
+- **Internal Training**: Organized in-house training sessions, workshops, or courses on SOPs, AI frameworks, or tools.
+
+## Key Roles
+
+- **Human Resources**: Maintains overall training records, ensures data integrity, and grants authorized access to records.
+- **Training Coordinator**: Oversees scheduling, communications, and logistics for training, and ensures documentation is submitted to HR.
+- **Line/Department Managers**: Approve attendance at training, verify alignment with job needs, and forward approvals to HR.
+- **Employees / Contract Staff**: Request training approval, attend training, submit evidence or certifications of completion to HR.
+- **Trainer**: Develop and deliver training content, provide attendance records and materials to the Training Coordinator.
+- **AI-IRB Liaison**: Validates that AI-related training meets regulatory and ethical guidelines, especially for sensitive AI modules.
+

--- a/lesson-plans/SOP-1101-01-AI_Training-and-Documentation-lesson-plan.md
+++ b/lesson-plans/SOP-1101-01-AI_Training-and-Documentation-lesson-plan.md
@@ -1,0 +1,35 @@
+# Lesson Plan Draft: Training and Documentation
+
+**SOP Reference:** SOP-1101-01-AI_Training-and-Documentation
+
+## Objective
+
+This SOP describes the method for identifying, analyzing, and preparing training and documentation materials necessary for effective deployment of AI-related enhancements or products to both internal functional units and external end-users under the AI-SDLC. Additionally, it outlines roles and responsibilities to ensure smooth knowledge transfer for AI-based or standard systems.
+
+Scope:
+
+* Covers all training (internal or external) required by the AI-SDLC, including product documentation, user manuals, and release notes.  
+* Encompasses the steps from requirements definition of training materials to the execution of training (including FOA, pilot sessions, and final user classes).  
+* Applies to internal staff (e.g., developers, testers, operations) and external clients or partners who receive training on AI products or features.  
+* Excludes new-hire onboarding training (handled by HR) except where AI compliance is mandatory.  
+* Incorporates possible AI-IRB or ethics regulatory oversight for AI-based solutions.
+
+## Audience & Applicability
+
+Covers Scope.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Training (Trainer/Group)**: Delivers training to internal or external personnel; ensures training content is accurate and current.
+- **Technical Support**: Defines initial training & documentation requirements; reviews produced materials; trains end-users.
+- **Product Group**: Works with Technical Support to gather training needs; ensures SOW identifies all required training.
+- **Development Group**: Produces or updates technical documents as per AI-SDLC scope; collaborates with QA on documentation.
+- **Quality Assurance (QA)**: Reviews, accepts/rejects documentation for completeness & accuracy; ensures it meets acceptance criteria.
+- **AI-IRB Liaison**: Ensures training meets AI ethical/compliance guidelines; reviews training content if mandated.
+- **Operations**: May assist in environment setup for training sessions or staging environment usage.
+- **Client/External User**: Receives training; completes Pre-Needs Assessment Form (as relevant); provides feedback.
+

--- a/lesson-plans/SOP-1200-01-AI_Development-lesson-plan.md
+++ b/lesson-plans/SOP-1200-01-AI_Development-lesson-plan.md
@@ -1,0 +1,28 @@
+# Lesson Plan Draft: Development
+
+**SOP Reference:** SOP-1200-01-AI_Development
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the process, responsibilities, and controls for designing, implementing, and testing system components during the Development phase of the AI-SDLC. The Development phase ensures all business and technical requirements are satisfied and ready for subsequent Testing, Validation, and Deployment.
+
+## Audience & Applicability
+
+Applies to all AI-related software/product development activities, including prototypes, enhancements, patches, bug fixes, and major releases.
+
+## Key Definitions
+
+- **AI-IRB Liaison**: The individual or committee representative responsible for overseeing compliance with AI risk management, alignment with ethical/regulatory standards, etc.
+- **Implementation Unit (IU)**: A distinct chunk of functionality, code, or script that can be developed, tested, and integrated independently, e.g., a class or module.
+- **VOB**: Versioned Object Base. Central source control repository that maintains versioned code, documentation, and other development artifacts.
+
+## Key Roles
+
+- **Project Manager**: Orchestrates project tasks, resource planning, timeline updates, and cross-team communication.
+- **Development Team Leader**: Oversees coding standards, assignment of Implementation Units (IUs), code review sessions, and ensures developer adherence to technical design.
+- **Developer**: Writes, integrates, and unit-tests code for assigned IUs, addresses assigned defects, and updates associated documentation in the VOB.
+- **Quality Assurance (QA)**: Reviews deliverables for compliance and completeness, performs acceptance of code prior to QA environment. Tests fixes for defects and ensures test coverage is achieved.
+- **Operations**: Prepares or reviews environment configurations, ensures successful builds for integration testing, and readies staging or production as needed.
+- **AI-IRB Liaison**: Conducts or coordinates AI risk assessment if new or changed AI-related functionality is introduced, providing sign-off or requiring additional compliance steps.
+- **Product Group**: Collaborates on design input, ensures final product meets business and user needs.
+

--- a/lesson-plans/SOP-1210-01-AI_Quality-Function-lesson-plan.md
+++ b/lesson-plans/SOP-1210-01-AI_Quality-Function-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: SOP-1210-01-AI_Quality-Function
+
+**SOP Reference:** SOP-1210-01-AI_Quality-Function
+
+## Objective
+
+The objective of this Standard Operating Procedure (SOP) is to establish and describe the **Quality Function** within the AI Systems Development Life Cycle (AI-SDLC). It details how quality oversight is conducted on product and project deliverables, ensuring alignment with regulatory requirements, user needs, and AI-IRB guidelines. This includes the creation of the **Quality Plan**, the development of test strategies and plans, validation activities, and acceptance criteria that guarantee high-quality AI-based products and services.
+
+## Audience & Applicability
+
+Applies to all AI-SDLC projects that require Quality Assurance (QA) oversight, from initial concept through post-deployment review. It addresses. Includes focus areas such as Planning and Strategy, Oversight, Validation, and Release.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI-QA Manager**: Oversees Quality Function, approves Test Strategies/Plans, coordinates QA resources, ensures compliance with AI-IRB.
+- **Quality Assurance Analyst**: Prepares quality plan, drafts test plans, performs inspections, manages defect logs, tracks testing progress.
+- **Development Team**: Provides technical design, code, and preliminary test results, fixes defects, addresses QA feedback.
+- **Operations**: Prepares test environments, ensures version control procedures, addresses environment issues discovered by QA.
+- **Product Manager**: Coordinates requirements with QA, ensures alignment with user needs, obtains resources for test execution.
+- **Program Manager**: Schedules overall AI-SDLC deliverables, ensures QA dependencies are addressed for each gate, communicates with sponsors
+- **AI-IRB Liaison**: Confirms that AI compliance guidelines are integrated into QA processes and are validated throughout.
+

--- a/lesson-plans/SOP-1220-01-AI_Deployment-lesson-plan.md
+++ b/lesson-plans/SOP-1220-01-AI_Deployment-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: Deployment (AI-SDLC)
+
+**SOP Reference:** SOP-1220-01-AI_Deployment
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the **planning and implementation requirements** for deploying AI-driven systems and enhancements into production as part of the **AI-SDLC** (Artificial Intelligence System Development Life Cycle). It ensures that releases meet **compliance** (including AI-IRB concerns), are fully tested, documented, and successfully transitioned to production/operations environments.
+
+## Audience & Applicability
+
+Encompasses all deployment stages of an AI-based or AI-affecting system.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **Development Lead**: Finalizes code, ensures release readiness, addresses any issues discovered during last-mile QA or user acceptance.
+- **QA Lead**: Validates system readiness, coordinates final acceptance testing, ensures that system is thoroughly tested and stable.
+- **Operations Manager**: Reviews and executes the deployment plan, sets up environments, performs the final “push,” and monitors post-release.
+- **Product/Project Mgr**: Communicates with stakeholders, obtains final approvals, orchestrates the release timeline, ensures full compliance.
+- **Program Manager**: Monitors overall resource usage, scheduling, cross-project dependencies, and coordinates with AI-IRB Liaison.
+- **Technical Support**: Schedules training, FOA/Beta support, coordinates user acceptance and go-live training, logs post-release issues.
+- **AI-IRB Liaison**: Confirms all AI-related compliance steps are completed before final push to production, addresses any regulatory steps.
+

--- a/lesson-plans/SOP-1300-01-AI_AI-IRB-Governance-and-Oversight-lesson-plan.md
+++ b/lesson-plans/SOP-1300-01-AI_AI-IRB-Governance-and-Oversight-lesson-plan.md
@@ -1,0 +1,27 @@
+# Lesson Plan Draft: AI-IRB Governance & Oversight
+
+**SOP Reference:** SOP-1300-01-AI_AI-IRB-Governance-and-Oversight
+
+## Objective
+
+The objective of this Standard Operating Procedure (SOP) is to define and document the governance structure and oversight responsibilities of the AI Institutional Review Board (AI-IRB) within the AI-SDLC framework. This SOP outlines the processes by which the AI-IRB evaluates, approves, and monitors AI projects to ensure compliance with ethical, regulatory, and organizational requirements.
+
+## Audience & Applicability
+
+Applies to all AI initiatives under the jurisdiction of the AI-IRB, including internal product development, external client engagements, research collaborations, and any other AI/ML-based or data-driven endeavors. It also governs the oversight and ethical review of AI models, tools, or algorithms developed or integrated into the production environment by the Performing Organization (Engineering), Contracting Organization (Product/Technical Support), or external partners.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI-IRB Chair**: Convenes AI-IRB meetings <br/>; Coordinates reviews, ensures conformance to policies <br/>; Approves final decisions
+- **AI-IRB Members**: Expert panelists across technical, legal, ethical, operational domains <br/>; Review project proposals, voice concerns, provide recommendations
+- **Project Sponsor**: Submits project proposal to AI-IRB <br/>; Addresses feedback/revisions required <br/>; Ensures resources for compliance
+- **AI Governance Office**: Maintains repository of AI-IRB decisions <br/>; Tracks open items and follow-ups <br/>; Communicates policy updates
+- **Engineering Dept.**: Implements required modifications from AI-IRB <br/>; Submits technical artifacts, ensures compliance with recommendations
+- **Product/Tech Support**: Provides user and client perspective <br/>; Coordinates training and user documentation with AI-IRB guidelines
+- **Operations**: Implements changes into production environments <br/>; Maintains logs/evidence of compliance post-release
+- **Senior Management**: Confirms alignment of AI-IRB with strategic direction <br/>; Resolves escalated issues or cross-organizational conflicts
+

--- a/lesson-plans/SOP-1301-01-AI_AI-Bias-and-Fairness-Evaluation-lesson-plan.md
+++ b/lesson-plans/SOP-1301-01-AI_AI-Bias-and-Fairness-Evaluation-lesson-plan.md
@@ -1,0 +1,26 @@
+# Lesson Plan Draft: SOP-1301-01-AI_AI-Bias-and-Fairness-Evaluation
+
+**SOP Reference:** SOP-1301-01-AI_AI-Bias-and-Fairness-Evaluation
+
+## Objective
+
+The purpose of this Standard Operating Procedure (SOP) is to establish a robust, standardized process for identifying, monitoring, and mitigating bias in AI systems developed or deployed within the organization. The SOP ensures that fairness considerations are consistently integrated into every phase of the AI Systems Development Life Cycle (AI-SDLC), thereby enhancing trust, compliance, and ethical alignment with regulatory requirements, including those mandated by the AI-IRB (Artificial Intelligence Institutional Review Board).
+
+## Audience & Applicability
+
+Applies to. Includes focus areas such as Applies To and Exclusions.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- **AI-IRB Chair & Members**: Review bias/fairness plans, verify compliance with policy and legal obligations, issue approval or corrective directions.
+- **Project Sponsor/Product Owner**: Ensure scope, timeline, and budget include bias & fairness tasks; respond to IRB feedback and incorporate changes.
+- **Data Scientists / ML Engineers**: Implement technical aspects of bias detection, fairness metrics, propose remediation solutions.
+- **QA / Validation Team**: Independently test for bias using established metrics and verifying the data scientists' results.
+- **AI Governance Office**: Maintain official documentation on bias/fairness evaluations, track compliance, liaise with IRB and Product Owners.
+- **Operations / Deployment Team**: Incorporate final bias remediation steps into production environment, coordinate logs/monitoring for bias detection.
+- **Technical Support**: Gather user feedback on potential unfair outcomes, funnel issues to QA or Data Scientists for re-check.
+

--- a/lesson-plans/SOP-1302-01-AI_AI-Explainability-and-Model-Transparency-lesson-plan.md
+++ b/lesson-plans/SOP-1302-01-AI_AI-Explainability-and-Model-Transparency-lesson-plan.md
@@ -1,0 +1,19 @@
+# Lesson Plan Draft: SOP-1302-01-AI_AI-Explainability-and-Model-Transparency
+
+**SOP Reference:** SOP-1302-01-AI_AI-Explainability-and-Model-Transparency
+
+## Objective
+
+Objective details not provided in the SOP.
+
+## Audience & Applicability
+
+Scope details not provided.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1303-01-AI_AI-Data-Protection-and-Privacy-lesson-plan.md
+++ b/lesson-plans/SOP-1303-01-AI_AI-Data-Protection-and-Privacy-lesson-plan.md
@@ -1,0 +1,19 @@
+# Lesson Plan Draft: AI Data Protection & Privacy
+
+**SOP Reference:** SOP-1303-01-AI_AI-Data-Protection-and-Privacy
+
+## Objective
+
+Objective details not provided in the SOP.
+
+## Audience & Applicability
+
+Scope details not provided.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1304-01-AI_AI-Validation-and-Monitoring-lesson-plan.md
+++ b/lesson-plans/SOP-1304-01-AI_AI-Validation-and-Monitoring-lesson-plan.md
@@ -1,0 +1,19 @@
+# Lesson Plan Draft: AI Validation & Monitoring
+
+**SOP Reference:** SOP-1304-01-AI_AI-Validation-and-Monitoring
+
+## Objective
+
+Objective details not provided in the SOP.
+
+## Audience & Applicability
+
+Scope details not provided.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1305-01-AI_AI-Ethical-Risk-and-Impact-Assessment-lesson-plan.md
+++ b/lesson-plans/SOP-1305-01-AI_AI-Ethical-Risk-and-Impact-Assessment-lesson-plan.md
@@ -1,0 +1,19 @@
+# Lesson Plan Draft: AI Ethical Risk & Impact Assessment
+
+**SOP Reference:** SOP-1305-01-AI_AI-Ethical-Risk-and-Impact-Assessment
+
+## Objective
+
+Objective details not provided in the SOP.
+
+## Audience & Applicability
+
+Scope details not provided.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-1306-01-AI_AI-End-of-Life-and-Sunset-Process-lesson-plan.md
+++ b/lesson-plans/SOP-1306-01-AI_AI-End-of-Life-and-Sunset-Process-lesson-plan.md
@@ -1,0 +1,19 @@
+# Lesson Plan Draft: AI End-of-Life & Sunset Process
+
+**SOP Reference:** SOP-1306-01-AI_AI-End-of-Life-and-Sunset-Process
+
+## Objective
+
+Objective details not provided in the SOP.
+
+## Audience & Applicability
+
+Scope details not provided.
+
+## Key Definitions
+
+- No key definitions provided.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/lesson-plans/SOP-2002-01-AI_Control-of-Quality-Records-lesson-plan.md
+++ b/lesson-plans/SOP-2002-01-AI_Control-of-Quality-Records-lesson-plan.md
@@ -1,0 +1,22 @@
+# Lesson Plan Draft: SOP-2002-01-AI_Control-of-Quality-Records
+
+**SOP Reference:** SOP-2002-01-AI_Control-of-Quality-Records
+
+## Objective
+
+This Standard Operating Procedure (SOP) defines the process for managing and controlling quality records throughout their lifecycle in the AI-SDLC (Artificial Intelligence System Development Life Cycle) environment. The goal is to ensure that all records—whether physical or electronic—are identifiable, retrievable, protected from damage or loss, and retained or disposed of in compliance with regulatory, contractual, and internal AI-IRB (AI Institutional Review Board) requirements.
+
+## Audience & Applicability
+
+Applies to all AI-SDLC projects and associated quality records generated, received, maintained, archived, or disposed of by the Performing Organization (e.g., Engineering Department) and the Contracting Organization (e.g., Product and Technical Support). This includes records relating to.
+
+## Key Definitions
+
+- **Quality Records**: Documents or electronic records that provide objective evidence of activities performed or results achieved, e.g., test reports, AI model performance logs, design review minutes, AI-IRB approvals, etc.
+- **AI-IRB**: AI Institutional Review Board overseeing compliance and ethics for AI systems.
+- **Record Retention Schedule**: The documented policy or grid specifying the minimum retention period for each type of quality record.
+- **Record Custodian**: The individual or department responsible for maintaining and securing a given set of records.
+
+## Key Roles
+
+- No roles and responsibilities provided.

--- a/scripts/generate_lesson_plans.py
+++ b/scripts/generate_lesson_plans.py
@@ -1,0 +1,282 @@
+import re
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOPS_DIR = REPO_ROOT / "sops"
+OUTPUT_DIR = REPO_ROOT / "lesson-plans"
+
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+SectionMap = Dict[str, List[str]]
+
+
+def cleanup_heading(raw: str) -> str:
+    text = raw.strip()
+    text = text.lstrip('#').strip()
+    if text.startswith('**') and text.endswith('**') and len(text) >= 4:
+        text = text[2:-2]
+    text = text.replace('\\', '')
+    text = re.sub(r'^\d+(\.\d+)*\s*', '', text)
+    return text.strip()
+
+
+def strip_markdown(text: str) -> str:
+    return re.sub(r'[*_`]', '', text)
+
+
+def extract_sections(lines: List[str]) -> SectionMap:
+    sections: SectionMap = {}
+    current = None
+    buffer: List[str] = []
+
+    for line in lines:
+        if line.strip().startswith('##'):
+            if current is not None:
+                sections[current] = buffer
+            current = cleanup_heading(line)
+            buffer = []
+        else:
+            if current is not None:
+                buffer.append(line.rstrip('\n'))
+    if current is not None:
+        sections[current] = buffer
+    return sections
+
+
+def find_section(sections: SectionMap, *keywords: str) -> List[str]:
+    for key, value in sections.items():
+        lower = key.lower()
+        for keyword in keywords:
+            if keyword.lower() in lower:
+                return value
+    return []
+
+
+def parse_title(lines: List[str], fallback: str) -> str:
+    for line in lines:
+        plain = line.replace('*', '')
+        match = re.search(r'\btitle\b[:：]\s*(.*)', plain, flags=re.IGNORECASE)
+        if match:
+            title = match.group(1).strip()
+            return title if title else fallback
+    # look for first markdown heading
+    for line in lines:
+        if line.startswith('#'):
+            title = cleanup_heading(line)
+            return title if title else fallback
+    return fallback
+
+
+def clean_text(cell: str) -> str:
+    text = cell.replace('**', '')
+    text = text.replace('\\-', '-')
+    text = text.replace('\\&', '&')
+    text = text.replace('\\', '')
+    text = text.replace('\n', ' ')
+    text = re.sub(r'\s+', ' ', text)
+    return text.strip()
+
+
+def parse_table(lines: List[str]) -> List[Tuple[str, str]]:
+    entries: List[Tuple[str, str]] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line.startswith('|'):
+            continue
+        cells = [c.strip() for c in line.strip('|').split('|')]
+        if len(cells) < 2:
+            continue
+        first, second = cells[0], cells[1]
+        if not first or set(first) <= {'-', ' '}:
+            continue
+        header_tokens = {'term', 'role', 'responsibilities', 'definition'}
+        if first.lower() in header_tokens or second.lower() in header_tokens:
+            continue
+        entries.append((clean_text(first), clean_text(second)))
+    return entries
+
+
+def format_responsibilities(text: str) -> str:
+    cleaned = clean_text(text)
+    if not cleaned:
+        return cleaned
+    if cleaned.startswith('-'):
+        parts = [part.strip() for part in re.split(r'-\s+', cleaned) if part.strip()]
+        if parts:
+            normalized = [part.rstrip(';.') for part in parts]
+            joined = '; '.join(normalized)
+            if cleaned.endswith('.'):
+                joined += '.'
+            return joined
+    return cleaned
+
+
+def format_list(items: List[str]) -> str:
+    if not items:
+        return ''
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ', '.join(items[:-1]) + f", and {items[-1]}"
+
+
+def restructure_scope_line(line: str, default_prefix: str) -> str:
+    text = re.sub(r'^[*-]\s*', '', line.strip())
+    text = text.replace('\\', '')
+    text = re.sub(r'\s+', ' ', text)
+    text = text.rstrip(':.')
+    trailing_phrases = [' including', ' including but not limited to', ' including without limitation', ' it encompasses']
+    lowered = text.lower()
+    for phrase in trailing_phrases:
+        if lowered.endswith(phrase):
+            text = text[: -len(phrase)]
+            break
+    text = re.sub(r',\s*$', '', text)
+    replacements = [
+        ('This SOP covers', 'Covers'),
+        ('This procedure covers', 'Covers'),
+        ('This policy covers', 'Covers'),
+        ('This SOP includes', 'Includes'),
+        ('This SOP encompasses', 'Encompasses'),
+        ('The scope includes', 'Includes'),
+        ('Scope includes', 'Includes'),
+        ('This SOP applies to', 'Applies to'),
+        ('This procedure applies to', 'Applies to'),
+        ('This policy applies to', 'Applies to'),
+        ('It applies to', 'Applies to'),
+        ('Applies to', 'Applies to'),
+        ('Applicable to', 'Applies to'),
+        ('The scope applies to', 'Applies to'),
+    ]
+    lowered = text.lower()
+    for old, new in replacements:
+        if lowered.startswith(old.lower()):
+            text = new + text[len(old):]
+            break
+    else:
+        if default_prefix and not re.match(r'^(covers|includes|addresses|outlines|focuses|guides|defines|encompasses|applies|sets)', lowered):
+            text = default_prefix + text
+    text = re.sub(r'^(Covers|Includes|Applies to|Addresses|Focuses on|Guides|Defines|Encompasses):\s*', r'\1 ', text)
+    text = text.rstrip('.')
+    text = text.strip()
+    if text:
+        text = text[0].upper() + text[1:]
+    return text + '.' if text else ''
+
+
+def summarize_scope(lines: List[str]) -> str:
+    entries: List[Tuple[str, bool]] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        is_bullet = bool(re.match(r'^[*-]', stripped))
+        without_marker = re.sub(r'^[*-]\s*', '', stripped)
+        cleaned = strip_markdown(without_marker)
+        if cleaned and not set(cleaned) <= {'-', ' '}:
+            entries.append((cleaned, is_bullet))
+
+    if not entries:
+        return 'Scope details not provided.'
+
+    phase_names: List[str] = []
+    for cleaned, is_bullet in entries:
+        if is_bullet:
+            match = re.match(r'([^:]+):', cleaned)
+            if match:
+                phase = match.group(1).strip()
+                if phase and phase not in phase_names:
+                    phase_names.append(phase)
+
+    non_bullet = [cleaned for cleaned, is_bullet in entries if not is_bullet]
+
+    cover_line = None
+    for line in non_bullet:
+        lowered = line.lower()
+        if any(keyword in lowered for keyword in ['scope', 'cover', 'encompass', 'include', 'govern', 'guide', 'appl']):
+            cover_line = line
+            break
+    if cover_line is None:
+        cover_line = non_bullet[0] if non_bullet else entries[0][0]
+
+    applies_line = None
+    for line in non_bullet:
+        if line == cover_line:
+            continue
+        lowered = line.lower()
+        if any(keyword in lowered for keyword in ['appl', 'team', 'stakeholder', 'audience', 'personnel', 'department', 'group']):
+            applies_line = line
+    if applies_line is None and len(non_bullet) > 1:
+        candidate = non_bullet[-1]
+        if candidate != cover_line:
+            applies_line = candidate
+
+    sentences: List[str] = []
+    if cover_line:
+        sentences.append(restructure_scope_line(cover_line, 'Covers '))
+    if phase_names:
+        sentences.append(f"Includes focus areas such as {format_list(phase_names)}.")
+    if applies_line:
+        applies_sentence = restructure_scope_line(applies_line, '')
+        if applies_sentence:
+            sentences.append(applies_sentence)
+
+    return ' '.join(sentences) if sentences else 'Scope details not provided.'
+
+
+def write_lesson_plan(sop_path: Path) -> None:
+    lines = sop_path.read_text(encoding='utf-8').splitlines()
+    sections = extract_sections(lines)
+    objective_lines = find_section(sections, 'objective', 'purpose')
+    scope_lines = find_section(sections, 'scope')
+    definitions_lines = find_section(sections, 'definition')
+    roles_lines = find_section(sections, 'role')
+
+    title = parse_title(lines, sop_path.stem)
+
+    output_path = OUTPUT_DIR / f"{sop_path.stem}-lesson-plan.md"
+    with output_path.open('w', encoding='utf-8') as fh:
+        fh.write(f"# Lesson Plan Draft: {title}\n\n")
+        fh.write(f"**SOP Reference:** {sop_path.stem}\n\n")
+
+        fh.write("## Objective\n\n")
+        if objective_lines:
+            filtered_objective = [line for line in objective_lines if line.strip() not in {'---', '***'}]
+            fh.write('\n'.join(filtered_objective).strip() + '\n\n')
+        else:
+            fh.write("Objective details not provided in the SOP.\n\n")
+
+        fh.write("## Audience & Applicability\n\n")
+        fh.write(summarize_scope(scope_lines) + "\n\n")
+
+        fh.write("## Key Definitions\n\n")
+        definitions = parse_table(definitions_lines)
+        if definitions:
+            for term, definition in definitions:
+                fh.write(f"- **{term}**: {definition}\n")
+            fh.write("\n")
+        else:
+            fh.write("- No key definitions provided.\n\n")
+
+        fh.write("## Key Roles\n\n")
+        roles = parse_table(roles_lines)
+        if roles:
+            for role, responsibilities in roles:
+                fh.write(f"- **{role}**: {format_responsibilities(responsibilities)}\n")
+            fh.write("\n")
+        else:
+            fh.write("- No roles and responsibilities provided.\n")
+
+
+def main() -> None:
+    sop_files = sorted(p for p in SOPS_DIR.glob('SOP-[0-9]*.md'))
+    if not sop_files:
+        raise SystemExit('No SOP files found.')
+    for path in sop_files:
+        write_lesson_plan(path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a generation script that parses SOP objective, scope, definitions, and roles content
- produce lesson plan drafts for each SOP with copied objectives, summarized scope, and key term/role notes

## Testing
- python scripts/generate_lesson_plans.py

------
https://chatgpt.com/codex/tasks/task_e_68c966e25938832fa0cd30c48a180529